### PR TITLE
ci: Reenable CodeCov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,11 @@ jobs:
       - name: Pack
         run: dotnet pack src/CompositeKey -c Release --no-build -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o _output
 
-      # Disabled due to Codecov throwing 500 errors
-      # - name: Upload Coverage
-      #   uses: codecov/codecov-action@v4
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     files: ./unit-test-results/*/coverage.opencover.xml
-      #     fail_ci_if_error: true
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./unit-test-results/*/coverage.opencover.xml
 
       - name: Push
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Disabled due to what I hope was a transient issue with CodeCov itself. Now appears to be working again so reintroducing this into the CI workflow.