### PR TITLE
refactor: Rename `CompositeSourceGenerator` to `SourceGenerator`

### DIFF
--- a/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace CompositeKey.SourceGeneration.UnitTests;
 
-public sealed record CompositeSourceGeneratorResult
+public sealed record SourceGeneratorResult
 {
     public required Compilation OutputCompilation { get; set; }
 
@@ -49,10 +49,10 @@ public static class CompilationHelper
         return CSharpSyntaxTree.ParseText(source, parseOptions ?? DefaultParseOptions);
     }
 
-    public static CSharpGeneratorDriver CreateCompositeSourceGeneratorDriver(
-        Compilation compilation, CompositeSourceGenerator? generator = null)
+    public static CSharpGeneratorDriver CreateSourceGeneratorDriver(
+        Compilation compilation, SourceGenerator? generator = null)
     {
-        generator ??= new CompositeSourceGenerator();
+        generator ??= new SourceGenerator();
 
         var parseOptions = compilation.SyntaxTrees
             .OfType<CSharpSyntaxTree>()
@@ -65,12 +65,12 @@ public static class CompilationHelper
             driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, true));
     }
 
-    public static CompositeSourceGeneratorResult RunCompositeSourceGenerator(Compilation compilation, bool disableDiagnosticValidation = false)
+    public static SourceGeneratorResult RunSourceGenerator(Compilation compilation, bool disableDiagnosticValidation = false)
     {
         var generationSpecs = ImmutableArray<GenerationSpec>.Empty;
-        var generator = new CompositeSourceGenerator { OnSourceEmitting = specs => generationSpecs = specs };
+        var generator = new SourceGenerator { OnSourceEmitting = specs => generationSpecs = specs };
 
-        var driver = CreateCompositeSourceGeneratorDriver(compilation, generator);
+        var driver = CreateSourceGeneratorDriver(compilation, generator);
         driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
 
         if (!disableDiagnosticValidation)
@@ -79,7 +79,7 @@ public static class CompilationHelper
             diagnostics.Where(d => d.Severity > DiagnosticSeverity.Info).Should().BeEmpty();
         }
 
-        return new CompositeSourceGeneratorResult()
+        return new SourceGeneratorResult()
         {
             OutputCompilation = outputCompilation,
             Diagnostics = diagnostics,

--- a/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorIncrementalTests.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorIncrementalTests.cs
@@ -5,13 +5,13 @@ using Microsoft.CodeAnalysis;
 
 namespace CompositeKey.SourceGeneration.UnitTests;
 
-public static class CompositeSourceGeneratorIncrementalTests
+public static class SourceGeneratorIncrementalTests
 {
     [Theory, MemberData(nameof(GetCompilationHelperFactories))]
     public static void CompilingTheSameSource_ShouldResultInStructurallyEqualModels(Func<Compilation> factory)
     {
-        var firstResult = CompilationHelper.RunCompositeSourceGenerator(factory(), disableDiagnosticValidation: true);
-        var secondResult = CompilationHelper.RunCompositeSourceGenerator(factory(), disableDiagnosticValidation: true);
+        var firstResult = CompilationHelper.RunSourceGenerator(factory(), disableDiagnosticValidation: true);
+        var secondResult = CompilationHelper.RunSourceGenerator(factory(), disableDiagnosticValidation: true);
 
         firstResult.GenerationSpecs.Length.Should().Be(secondResult.GenerationSpecs.Length);
 
@@ -55,8 +55,8 @@ public static class CompositeSourceGeneratorIncrementalTests
                                     }
                                     """;
 
-        var firstResult = CompilationHelper.RunCompositeSourceGenerator(CompilationHelper.CreateCompilation(FirstSource));
-        var secondResult = CompilationHelper.RunCompositeSourceGenerator(CompilationHelper.CreateCompilation(SecondSource));
+        var firstResult = CompilationHelper.RunSourceGenerator(CompilationHelper.CreateCompilation(FirstSource));
+        var secondResult = CompilationHelper.RunSourceGenerator(CompilationHelper.CreateCompilation(SecondSource));
 
         firstResult.GenerationSpecs.Should().HaveCount(1);
         var firstGenerationSpec = firstResult.GenerationSpecs[0];
@@ -94,8 +94,8 @@ public static class CompositeSourceGeneratorIncrementalTests
                                    public partial record BasicPrimaryKey(Guid DifferentPartName, Guid SecondPart, Guid ThirdPart);
                                    """;
 
-        var firstResult = CompilationHelper.RunCompositeSourceGenerator(CompilationHelper.CreateCompilation(FirstSource));
-        var secondResult = CompilationHelper.RunCompositeSourceGenerator(CompilationHelper.CreateCompilation(SecondSource));
+        var firstResult = CompilationHelper.RunSourceGenerator(CompilationHelper.CreateCompilation(FirstSource));
+        var secondResult = CompilationHelper.RunSourceGenerator(CompilationHelper.CreateCompilation(SecondSource));
 
         firstResult.GenerationSpecs.Should().HaveCount(1);
         var firstGenerationSpec = firstResult.GenerationSpecs[0];
@@ -111,7 +111,7 @@ public static class CompositeSourceGeneratorIncrementalTests
     [Theory, MemberData(nameof(GetCompilationHelperFactories))]
     public static void SourceGenerationSpecModel_ShouldNotEncapsulateSymbolsOrCompilationData(Func<Compilation> factory)
     {
-        var result = CompilationHelper.RunCompositeSourceGenerator(factory(), disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(factory(), disableDiagnosticValidation: true);
         WalkObjectGraphAndAssert(result.GenerationSpecs, []);
         WalkObjectGraphAndAssert(result.Diagnostics, []);
 
@@ -146,7 +146,7 @@ public static class CompositeSourceGeneratorIncrementalTests
     {
         var compilation = factory();
 
-        GeneratorDriver generatorDriver = CompilationHelper.CreateCompositeSourceGeneratorDriver(compilation);
+        GeneratorDriver generatorDriver = CompilationHelper.CreateSourceGeneratorDriver(compilation);
 
         generatorDriver = generatorDriver.RunGenerators(compilation);
         var result = generatorDriver.GetRunResult().Results[0];
@@ -190,7 +190,7 @@ public static class CompositeSourceGeneratorIncrementalTests
         return;
 
         static IncrementalGeneratorRunStep[]? GetGeneratorRunSteps(GeneratorRunResult result) =>
-            !result.TrackedSteps.TryGetValue(CompositeSourceGenerator.GenerationSpecTrackingName, out var steps) ? null : steps.ToArray();
+            !result.TrackedSteps.TryGetValue(SourceGenerator.GenerationSpecTrackingName, out var steps) ? null : steps.ToArray();
     }
 
     [Fact]
@@ -220,12 +220,12 @@ public static class CompositeSourceGeneratorIncrementalTests
                                       """;
 
         var compilation = CompilationHelper.CreateCompilation(InitialSource);
-        GeneratorDriver generatorDriver = CompilationHelper.CreateCompositeSourceGeneratorDriver(compilation);
+        GeneratorDriver generatorDriver = CompilationHelper.CreateSourceGeneratorDriver(compilation);
 
         generatorDriver = generatorDriver.RunGenerators(compilation);
         var result = generatorDriver.GetRunResult().Results[0];
 
-        foreach (var step in result.TrackedSteps[CompositeSourceGenerator.GenerationSpecTrackingName])
+        foreach (var step in result.TrackedSteps[SourceGenerator.GenerationSpecTrackingName])
         {
             foreach ((var source, int outputIndex) in step.Inputs)
                 source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.New);
@@ -239,7 +239,7 @@ public static class CompositeSourceGeneratorIncrementalTests
         generatorDriver = generatorDriver.RunGenerators(compilation);
         result = generatorDriver.GetRunResult().Results[0];
 
-        foreach (var step in result.TrackedSteps[CompositeSourceGenerator.GenerationSpecTrackingName])
+        foreach (var step in result.TrackedSteps[SourceGenerator.GenerationSpecTrackingName])
         {
             foreach ((var source, int outputIndex) in step.Inputs)
                 source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.Modified);
@@ -273,12 +273,12 @@ public static class CompositeSourceGeneratorIncrementalTests
                                       """;
 
         var compilation = CompilationHelper.CreateCompilation(InitialSource);
-        GeneratorDriver generatorDriver = CompilationHelper.CreateCompositeSourceGeneratorDriver(compilation);
+        GeneratorDriver generatorDriver = CompilationHelper.CreateSourceGeneratorDriver(compilation);
 
         generatorDriver = generatorDriver.RunGenerators(compilation);
         var result = generatorDriver.GetRunResult().Results[0];
 
-        foreach (var step in result.TrackedSteps[CompositeSourceGenerator.GenerationSpecTrackingName])
+        foreach (var step in result.TrackedSteps[SourceGenerator.GenerationSpecTrackingName])
         {
             foreach ((var source, int outputIndex) in step.Inputs)
                 source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.New);
@@ -292,7 +292,7 @@ public static class CompositeSourceGeneratorIncrementalTests
         generatorDriver = generatorDriver.RunGenerators(compilation);
         result = generatorDriver.GetRunResult().Results[0];
 
-        foreach (var step in result.TrackedSteps[CompositeSourceGenerator.GenerationSpecTrackingName])
+        foreach (var step in result.TrackedSteps[SourceGenerator.GenerationSpecTrackingName])
         {
             foreach ((var source, int outputIndex) in step.Inputs)
                 source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.Modified);

--- a/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorTests.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorTests.cs
@@ -3,7 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace CompositeKey.SourceGeneration.UnitTests;
 
-public static class CompositeSourceGeneratorTests
+public static class SourceGeneratorTests
 {
     [Fact]
     public static void ProgramThatDoesNotUseCompositeKey_ShouldStillSuccessfullyCompile()
@@ -21,70 +21,70 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void BasicPrimaryKey_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithBasicPrimaryKey();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void BasicCompositePrimaryKey_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithBasicCompositePrimaryKey();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void ClashingKeyNames_ShouldStillSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithClashingKeyNames();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void KeyHasInitOnlyProperties_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithInitOnlyProperties();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void KeyHasConstructableInitOnlyProperties_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithConstructableInitOnlyProperties();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void KeyHasRequiredProperties_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithRequiredProperties();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void KeyHasConstructorThatSetsRequiredProperties_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithConstructorThatSetsRequiredProperties();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void KeyHasNestedTypeDeclarations_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithNestedTypeDeclarations();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void KeyIsPrivateInNestedTypeDeclarations_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithNestedPrivateTypeDeclarations();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Theory]
@@ -108,7 +108,7 @@ public static class CompositeSourceGeneratorTests
 
         var parseOptions = CompilationHelper.CreateParseOptions(languageVersion);
         var compilation = CompilationHelper.CreateCompilation(Source, parseOptions: parseOptions);
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Theory]
@@ -128,7 +128,7 @@ public static class CompositeSourceGeneratorTests
 
         var parseOptions = CompilationHelper.CreateParseOptions(languageVersion);
         var compilation = CompilationHelper.CreateCompilation(Source, parseOptions: parseOptions);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -157,7 +157,7 @@ public static class CompositeSourceGeneratorTests
                           """;
 
         var compilation = CompilationHelper.CreateCompilation(source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -184,7 +184,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -217,7 +217,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -250,7 +250,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -287,7 +287,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
@@ -304,7 +304,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -333,7 +333,7 @@ public static class CompositeSourceGeneratorTests
                          """;
 
         var compilation = CompilationHelper.CreateCompilation(source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -360,7 +360,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -390,7 +390,7 @@ public static class CompositeSourceGeneratorTests
                          """;
 
         var compilation = CompilationHelper.CreateCompilation(source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -426,7 +426,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -464,7 +464,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -493,7 +493,7 @@ public static class CompositeSourceGeneratorTests
                               """;
 
         var compilation = CompilationHelper.CreateCompilation(Source);
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 
@@ -512,14 +512,14 @@ public static class CompositeSourceGeneratorTests
     public static void KeyHasExplicitlyMarkedConstructor_ShouldSuccessfullyCompile()
     {
         var compilation = CompilationHelper.CreateCompilationWithExplicitlyMarkedConstructor();
-        CompilationHelper.RunCompositeSourceGenerator(compilation);
+        CompilationHelper.RunSourceGenerator(compilation);
     }
 
     [Fact]
     public static void KeyHasMultipleExplicitlyMarkedConstructors_ShouldFailCompilation()
     {
         var compilation = CompilationHelper.CreateCompilationWithMultipleExplicitlyMarkedConstructors();
-        var result = CompilationHelper.RunCompositeSourceGenerator(compilation, disableDiagnosticValidation: true);
+        var result = CompilationHelper.RunSourceGenerator(compilation, disableDiagnosticValidation: true);
 
         var location = compilation.GetSymbolsWithName("BasicPrimaryKey").First().Locations[0];
 

--- a/src/CompositeKey.SourceGeneration/SourceGenerator.DiagnoticDescriptors.cs
+++ b/src/CompositeKey.SourceGeneration/SourceGenerator.DiagnoticDescriptors.cs
@@ -3,7 +3,7 @@ using Microsoft.CodeAnalysis;
 
 namespace CompositeKey.SourceGeneration;
 
-public sealed partial class CompositeSourceGenerator
+public sealed partial class SourceGenerator
 {
     internal static class DiagnosticDescriptors
     {

--- a/src/CompositeKey.SourceGeneration/SourceGenerator.Emitter.cs
+++ b/src/CompositeKey.SourceGeneration/SourceGenerator.Emitter.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace CompositeKey.SourceGeneration;
 
-public sealed partial class CompositeSourceGenerator
+public sealed partial class SourceGenerator
 {
     private sealed class Emitter(SourceProductionContext context)
     {

--- a/src/CompositeKey.SourceGeneration/SourceGenerator.Parser.cs
+++ b/src/CompositeKey.SourceGeneration/SourceGenerator.Parser.cs
@@ -14,7 +14,7 @@ namespace CompositeKey.SourceGeneration;
 
 public sealed record CompositeKeyAttributeValues(string TemplateString, char? PrimaryKeySeparator);
 
-public sealed partial class CompositeSourceGenerator
+public sealed partial class SourceGenerator
 {
     private const string CompositeKeyAttributeFullName = "CompositeKey.CompositeKeyAttribute";
 

--- a/src/CompositeKey.SourceGeneration/SourceGenerator.cs
+++ b/src/CompositeKey.SourceGeneration/SourceGenerator.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace CompositeKey.SourceGeneration;
 
 [Generator]
-public sealed partial class CompositeSourceGenerator : IIncrementalGenerator
+public sealed partial class SourceGenerator : IIncrementalGenerator
 {
     public const string GenerationSpecTrackingName = nameof(GenerationSpec);
 


### PR DESCRIPTION
There was no need really to specify `Composite*` as there's only one source generator in the project.