### PR TITLE
ci: Update GitVersion and Actions Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Restore
         run: dotnet restore --locked-mode
       - name: Build
-        run: dotnet build -c Release --no-restore -p:PackageVersion=${{ steps.gitversion.outputs.semVer }}
+        run: dotnet build -c Release --no-restore -p:Version=${{ steps.gitversion.outputs.semVer }} -p:PackageVersion=${{ steps.gitversion.outputs.semVer }}
       - name: Unit Test
         run: dotnet test src/CompositeKey.SourceGeneration.UnitTests -c Release --no-restore --no-build --collect:"XPlat Code Coverage" --results-directory unit-test-results -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       - name: Functional Test
         run: dotnet test src/CompositeKey.SourceGeneration.FunctionalTests -c Release --no-restore --no-build
       - name: Pack
-        run: dotnet pack src/CompositeKey -c Release --no-build -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o _output
+        run: dotnet pack src/CompositeKey -c Release --no-build -p:Version=${{ steps.gitversion.outputs.semVer }} -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o _output
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,3 +2,7 @@ branches:
   main:
     mode: ContinuousDeployment
     tag: preview
+
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-,/\\\\]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s-,/\\\\]*\\))?:"
+patch-version-bump-message: "^(fix|perf)(\\([\\w\\s-,/\\\\]*\\))?:"


### PR DESCRIPTION
Updates the configuration for GitVersion so that it respects Conventional Commits when deciding the next version number to use.

Also update the workflow so that it only publishes to NuGet on manual workflow dispatches.