### PR TITLE
build: Add PublicAPI Analyzer

### DIFF
--- a/src/CompositeKey/CompositeKey.csproj
+++ b/src/CompositeKey/CompositeKey.csproj
@@ -11,6 +11,13 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\CompositeKey.SourceGeneration\CompositeKey.SourceGeneration.csproj" ReferenceOutputAssembly="false" PackAsAnalyzer="true" />
     </ItemGroup>
 

--- a/src/CompositeKey/PublicAPI.Shipped.txt
+++ b/src/CompositeKey/PublicAPI.Shipped.txt
@@ -1,0 +1,22 @@
+﻿#nullable enable
+
+CompositeKey.CompositeKeyAttribute
+CompositeKey.CompositeKeyAttribute.CompositeKeyAttribute(string! template) -> void
+CompositeKey.CompositeKeyAttribute.PrimaryKeySeparator.get -> char
+CompositeKey.CompositeKeyAttribute.PrimaryKeySeparator.set -> void
+CompositeKey.CompositeKeyAttribute.Template.get -> string!
+CompositeKey.CompositeKeyConstructorAttribute
+CompositeKey.CompositeKeyConstructorAttribute.CompositeKeyConstructorAttribute() -> void
+CompositeKey.ICompositePrimaryKey<TSelf>
+CompositeKey.ICompositePrimaryKey<TSelf>.Parse(System.ReadOnlySpan<char> partitionKey, System.ReadOnlySpan<char> sortKey) -> TSelf
+CompositeKey.ICompositePrimaryKey<TSelf>.Parse(string! partitionKey, string! sortKey) -> TSelf
+CompositeKey.ICompositePrimaryKey<TSelf>.ToSortKeyString() -> string!
+CompositeKey.ICompositePrimaryKey<TSelf>.TryParse(System.ReadOnlySpan<char> partitionKey, System.ReadOnlySpan<char> sortKey, out TSelf result) -> bool
+CompositeKey.ICompositePrimaryKey<TSelf>.TryParse(string? partitionKey, string? sortKey, out TSelf result) -> bool
+CompositeKey.IPrimaryKey<TSelf>
+CompositeKey.IPrimaryKey<TSelf>.Parse(System.ReadOnlySpan<char> primaryKey) -> TSelf
+CompositeKey.IPrimaryKey<TSelf>.Parse(string! primaryKey) -> TSelf
+CompositeKey.IPrimaryKey<TSelf>.ToPartitionKeyString() -> string!
+CompositeKey.IPrimaryKey<TSelf>.ToString() -> string!
+CompositeKey.IPrimaryKey<TSelf>.TryParse(System.ReadOnlySpan<char> primaryKey, out TSelf result) -> bool
+CompositeKey.IPrimaryKey<TSelf>.TryParse(string? primaryKey, out TSelf result) -> bool

--- a/src/CompositeKey/PublicAPI.Unshipped.txt
+++ b/src/CompositeKey/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/CompositeKey/packages.lock.json
+++ b/src/CompositeKey/packages.lock.json
@@ -7,6 +7,12 @@
         "requested": "[1.2.25, )",
         "resolved": "1.2.25",
         "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
+      },
+      "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "kNLTfXtXUWDHVt5iaPkkiPuyHYlMgLI6SOFT4w88bfeI2vqSeGgHunFkdvlaCM8RDfcY0t2+jnesQtidRJJ/DA=="
       }
     }
   }


### PR DESCRIPTION
Enables the `Microsoft.CodeAnalysis.PublicApiAnalyzers` analyzer to help identify and avoid breaking changes.

All current APIs have been documented as "Shipped".