### PR TITLE
feat: Add option to disable/enable `InvariantCulture`

### DIFF
--- a/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
@@ -118,6 +118,16 @@ public static class CompilationHelper
         public partial record BasicPrimaryKey(Guid FirstPart, string SecondPart, CustomEnum ThirdPart);
         """);
 
+    public static Compilation CreateCompilationWithInvariantCultureDisabled() => CreateCompilation("""
+        using System;
+        using CompositeKey;
+
+        namespace UnitTests;
+
+        [CompositeKey("{FirstPart:B}#{SecondPart}|{ThirdPart}", PrimaryKeySeparator = '|', InvariantCulture = false)]
+        public partial record BasicPrimaryKey(Guid FirstPart, double SecondPart, string ThirdPart);
+        """);
+
     public static Compilation CreateCompilationWithClashingKeyNames() => CreateCompilation("""
         using System;
         using CompositeKey;

--- a/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorTests.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorTests.cs
@@ -39,6 +39,13 @@ public static class SourceGeneratorTests
     }
 
     [Fact]
+    public static void InvariantCultureDisabled_ShouldSuccessfullyGenerateSource()
+    {
+        var compilation = CompilationHelper.CreateCompilationWithInvariantCultureDisabled();
+        CompilationHelper.RunSourceGenerator(compilation);
+    }
+
+    [Fact]
     public static void ClashingKeyNames_ShouldStillSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithClashingKeyNames();

--- a/src/CompositeKey.SourceGeneration/Model/Key/CompositePrimaryKeySpec.cs
+++ b/src/CompositeKey.SourceGeneration/Model/Key/CompositePrimaryKeySpec.cs
@@ -3,8 +3,9 @@
 namespace CompositeKey.SourceGeneration.Model.Key;
 
 public sealed record CompositePrimaryKeySpec(
+    bool InvariantFormatting,
     ImmutableEquatableArray<KeyPart> AllParts,
     ImmutableEquatableArray<KeyPart> PartitionKeyParts,
     PrimaryDelimiterKeyPart PrimaryDelimiterKeyPart,
     ImmutableEquatableArray<KeyPart> SortKeyParts)
-    : KeySpec;
+    : KeySpec(InvariantFormatting);

--- a/src/CompositeKey.SourceGeneration/Model/Key/KeySpec.cs
+++ b/src/CompositeKey.SourceGeneration/Model/Key/KeySpec.cs
@@ -1,3 +1,3 @@
 ﻿namespace CompositeKey.SourceGeneration.Model.Key;
 
-public abstract record KeySpec;
+public abstract record KeySpec(bool InvariantFormatting);

--- a/src/CompositeKey.SourceGeneration/Model/Key/PrimaryKeySpec.cs
+++ b/src/CompositeKey.SourceGeneration/Model/Key/PrimaryKeySpec.cs
@@ -3,5 +3,6 @@
 namespace CompositeKey.SourceGeneration.Model.Key;
 
 public sealed record PrimaryKeySpec(
+    bool InvariantFormatting,
     ImmutableEquatableArray<KeyPart> Parts)
-    : KeySpec;
+    : KeySpec(InvariantFormatting);

--- a/src/CompositeKey/CompositeKeyAttribute.cs
+++ b/src/CompositeKey/CompositeKeyAttribute.cs
@@ -34,4 +34,11 @@ sealed class CompositeKeyAttribute(string template) : Attribute
     /// </remarks>
     /// <example>|</example>
     public char PrimaryKeySeparator { get; set; }
+
+    /// <summary>
+    /// Optional, when enabled the formatting of values in generated ToString/Format methods will use
+    /// <see cref="System.Globalization.CultureInfo.InvariantCulture"/> instead of the default/current culture.
+    /// </summary>
+    /// <remarks>This is enabled by default, to use the current culture instead set this property to <c>false</c>.</remarks>
+    public bool InvariantCulture { get; set; } = true;
 }

--- a/src/CompositeKey/PublicAPI.Shipped.txt
+++ b/src/CompositeKey/PublicAPI.Shipped.txt
@@ -2,6 +2,8 @@
 
 CompositeKey.CompositeKeyAttribute
 CompositeKey.CompositeKeyAttribute.CompositeKeyAttribute(string! template) -> void
+CompositeKey.CompositeKeyAttribute.InvariantCulture.get -> bool
+CompositeKey.CompositeKeyAttribute.InvariantCulture.set -> void
 CompositeKey.CompositeKeyAttribute.PrimaryKeySeparator.get -> char
 CompositeKey.CompositeKeyAttribute.PrimaryKeySeparator.set -> void
 CompositeKey.CompositeKeyAttribute.Template.get -> string!


### PR DESCRIPTION
Adds an option to disable using `InvariantCulture` format provider when formatting values in composite keys.