### PR TITLE
feat: Fast path `Format`/`Parse` generation for Enums

### DIFF
--- a/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeyTests.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeyTests.cs
@@ -243,4 +243,38 @@ public static class PrimaryKeyTests
     ];
 
     #endregion
+
+    #region PrimaryKeyWithFastPathFormatting
+
+    [Theory, AutoData]
+    public static void PrimaryKeyWithFastPathFormatting_RoundTripToStringAndParse_ShouldResultInEquivalentKey(
+        PrimaryKeyWithFastPathFormatting primaryKey)
+    {
+        var result = PrimaryKeyWithFastPathFormatting.Parse(primaryKey.ToString());
+
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(primaryKey);
+    }
+
+    [Theory, AutoData]
+    public static void PrimaryKeyWithFastPathFormatting_ToString_ShouldReturnCorrectlyFormattedString(
+        PrimaryKeyWithFastPathFormatting primaryKey)
+    {
+        string result = primaryKey.ToString();
+
+        result.Should().NotBeNull();
+        result.Should().Be($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.AnotherGuid}");
+    }
+
+    [Theory, AutoData]
+    public static void PrimaryKeyWithFastPathFormatting_ToPartitionKeyString_ShouldReturnCorrectlyFormattedString(
+        PrimaryKeyWithFastPathFormatting primaryKey)
+    {
+        string result = primaryKey.ToPartitionKeyString();
+
+        result.Should().NotBeNull();
+        result.Should().Be($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.AnotherGuid}");
+    }
+
+    #endregion
 }

--- a/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeys.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeys.cs
@@ -17,3 +17,9 @@ public sealed partial record MixedTypePrimaryKey(Guid GuidValue, int IntValue, s
 
 [CompositeKey("ConstantValue#{DynamicValue}@ConstantStringAtEndOfKey")]
 public sealed partial record PrimaryKeyWithConstants(Guid DynamicValue);
+
+[CompositeKey("{GuidValue}#Constant#{EnumValue}@{AnotherGuid}")]
+public sealed partial record PrimaryKeyWithFastPathFormatting(Guid GuidValue, PrimaryKeyWithFastPathFormatting.EnumType EnumValue, Guid AnotherGuid)
+{
+    public enum EnumType { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
+}

--- a/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
@@ -112,10 +112,22 @@ public static class CompilationHelper
 
         namespace UnitTests;
 
-        public enum CustomEnum { One = 1, Two = 2, Three = 3 };
+        public enum CustomEnum { One, Two, Three };
 
         [CompositeKey("{FirstPart:B}#{SecondPart}|ConstantValue#{ThirdPart}", PrimaryKeySeparator = '|')]
         public partial record BasicPrimaryKey(Guid FirstPart, string SecondPart, CustomEnum ThirdPart);
+        """);
+
+    public static Compilation CreateCompilationWithBasicNonSequentialEnumPrimaryKey() => CreateCompilation("""
+        using System;
+        using CompositeKey;
+
+        namespace UnitTests;
+
+        public enum CustomEnum { One = 3, Two = 2, Three = 1 };
+
+        [CompositeKey("{FirstPart:B}#{SecondPart}|ConstantValue#{ThirdPart}", PrimaryKeySeparator = '|')]
+        public partial record BasicNonSequentialEnum(Guid FirstPart, string SecondPart, CustomEnum ThirdPart);
         """);
 
     public static Compilation CreateCompilationWithInvariantCultureDisabled() => CreateCompilation("""

--- a/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorTests.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorTests.cs
@@ -39,6 +39,13 @@ public static class SourceGeneratorTests
     }
 
     [Fact]
+    public static void BasicNonSequentialEnumPrimaryKey_ShouldSuccessfullyGenerateSource()
+    {
+        var compilation = CompilationHelper.CreateCompilationWithBasicNonSequentialEnumPrimaryKey();
+        CompilationHelper.RunSourceGenerator(compilation);
+    }
+
+    [Fact]
     public static void InvariantCultureDisabled_ShouldSuccessfullyGenerateSource()
     {
         var compilation = CompilationHelper.CreateCompilationWithInvariantCultureDisabled();

--- a/src/CompositeKey.SourceGeneration/Core/SourceWriter.cs
+++ b/src/CompositeKey.SourceGeneration/Core/SourceWriter.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace CompositeKey.SourceGeneration.Core;
 
-internal sealed class SourceWriter
+public sealed class SourceWriter
 {
     private readonly StringBuilder _stringBuilder = new();
 
@@ -20,6 +20,27 @@ internal sealed class SourceWriter
 
             _indentation = value;
         }
+    }
+
+    public IDisposable Block(string? statement = null, bool endWithSemicolon = false)
+    {
+        StartBlock(statement);
+        return new ActionOnDisposal(() => EndBlock(endWithSemicolon));
+    }
+
+    public void StartBlock(string? statement = null)
+    {
+        if (statement is not null)
+            WriteLine(statement);
+
+        WriteLine("{");
+        Indentation++;
+    }
+
+    public void EndBlock(bool withSemicolon = false)
+    {
+        Indentation--;
+        WriteLine($"}}{(withSemicolon ? ";" : string.Empty)}");
     }
 
     public void WriteLine() => _stringBuilder.AppendLine();
@@ -91,4 +112,9 @@ internal sealed class SourceWriter
     }
 
     private void AddIndentation() => _stringBuilder.Append(' ', _indentation * 4);
+
+    private sealed class ActionOnDisposal(Action action) : IDisposable
+    {
+        public void Dispose() => action.Invoke();
+    }
 }

--- a/src/CompositeKey.SourceGeneration/EnumGenerationHelper.cs
+++ b/src/CompositeKey.SourceGeneration/EnumGenerationHelper.cs
@@ -1,0 +1,114 @@
+﻿using CompositeKey.SourceGeneration.Core;
+using CompositeKey.SourceGeneration.Model;
+
+namespace CompositeKey.SourceGeneration;
+
+public static class EnumGenerationHelper
+{
+    private const string MaybeNullWhen = "global::System.Diagnostics.CodeAnalysis.MaybeNullWhen";
+
+    public static void EmitEnumHelperClass(SourceWriter writer, EnumSpec enumSpec)
+    {
+        using var classBlock = writer.Block($"file class {enumSpec.Name}Helper");
+
+        if (enumSpec.IsSequentialFromZero)
+        {
+            writer.WriteLine($"private static readonly int[] Lengths = new[] {{ {string.Join(", ", enumSpec.Members.Select(m => m.Name.Length))} }};");
+            writer.WriteLine($"private static readonly string[] Names = new[] {{ {string.Join(", ", enumSpec.Members.Select(m => $"\"{m.Name}\""))} }};");
+            writer.WriteLine();
+        }
+
+        WriteGetFormattedLengthMethod(writer, enumSpec);
+        writer.WriteLine();
+
+        WriteTryFormatMethod(writer, enumSpec);
+        writer.WriteLine();
+
+        WriteTryParseMethod(writer, enumSpec);
+        writer.WriteLine();
+    }
+
+    private static void WriteGetFormattedLengthMethod(SourceWriter writer, EnumSpec enumSpec)
+    {
+        using var methodBlock = writer.Block($"public static int GetFormattedLength({enumSpec.FullyQualifiedName} value)");
+
+        if (enumSpec.IsSequentialFromZero)
+        {
+            writer.WriteLine("return Lengths[(uint)value];");
+        }
+        else
+        {
+            using var switchStatement = writer.Block("return value switch", true);
+
+            foreach ((string memberName, _) in enumSpec.Members)
+                writer.WriteLine($"{enumSpec.FullyQualifiedName}.{memberName} => {memberName.Length},");
+
+            writer.WriteLine("_ => throw new ArgumentOutOfRangeException(nameof(value), value, \"The value provided is out of range.\")");
+        }
+    }
+
+    private static void WriteTryFormatMethod(SourceWriter writer, EnumSpec enumSpec)
+    {
+        using var methodBlock = writer.Block($"public static bool TryFormat({enumSpec.FullyQualifiedName} value, Span<char> destination, out int charsWritten)");
+
+        if (enumSpec.IsSequentialFromZero)
+        {
+            writer.WriteLines("""
+                              charsWritten = 0;
+                              if ((uint)value >= Names.Length)
+                                  return false;
+
+                              int formattedLength = Lengths[(uint)value];
+                              if (destination.Length < formattedLength)
+                                  return false;
+
+                              charsWritten = formattedLength;
+                              Names[(uint)value].CopyTo(destination);
+                              return true;
+                              """);
+        }
+        else
+        {
+            writer.WriteLines("""
+                              charsWritten = GetFormattedLength(value);
+                              if (destination.Length < charsWritten)
+                                  return false;
+
+                              """);
+
+            using var switchBlock = writer.Block("switch (value)");
+
+            foreach ((string memberName, _) in enumSpec.Members)
+                writer.WriteLines($"""
+                                   case {enumSpec.FullyQualifiedName}.{memberName}:
+                                       "{memberName}".CopyTo(destination);
+                                       return true;
+                                   """);
+
+            writer.WriteLines("""
+                              default:
+                                  charsWritten = 0;
+                                  return false;
+                              """);
+        }
+    }
+
+    private static void WriteTryParseMethod(SourceWriter writer, EnumSpec enumSpec)
+    {
+        using var methodBlock = writer.Block($"public static bool TryParse(in ReadOnlySpan<char> value, [{MaybeNullWhen}(false)] out {enumSpec.FullyQualifiedName} result)");
+        using var switchBlock = writer.Block("switch (value)");
+
+        foreach ((string memberName, _) in enumSpec.Members)
+            writer.WriteLines($"""
+                               case var _ when value.Equals(nameof({enumSpec.FullyQualifiedName}.{memberName}), StringComparison.Ordinal):
+                                   result = {enumSpec.FullyQualifiedName}.{memberName};
+                                   return true;
+                               """);
+
+        writer.WriteLines("""
+                          default:
+                              result = default;
+                              return false;
+                          """);
+    }
+}

--- a/src/CompositeKey.SourceGeneration/Model/EnumSpec.cs
+++ b/src/CompositeKey.SourceGeneration/Model/EnumSpec.cs
@@ -1,0 +1,13 @@
+﻿using CompositeKey.SourceGeneration.Core;
+
+namespace CompositeKey.SourceGeneration.Model;
+
+public sealed record EnumSpec(
+    string Name,
+    string FullyQualifiedName,
+    string UnderlyingType,
+    ImmutableEquatableArray<EnumSpec.Member> Members,
+    bool IsSequentialFromZero)
+{
+    public sealed record Member(string Name, object Value);
+}

--- a/src/CompositeKey.SourceGeneration/Model/PropertySpec.cs
+++ b/src/CompositeKey.SourceGeneration/Model/PropertySpec.cs
@@ -7,4 +7,5 @@ public sealed record PropertySpec(
     bool IsRequired,
     bool HasGetter,
     bool HasSetter,
-    bool IsInitOnlySetter);
+    bool IsInitOnlySetter,
+    EnumSpec? EnumSpec);


### PR DESCRIPTION
Adds a capability into the generator to optimize the usage of Enums in Format/Parse code generation.

For each enum we generate a `{EnumName}Helper` file scoped class, this holds methods with optimal implementations so that they can be used in the fast path for Formatting. Additionally, with this change we source generate an implementation of TryParse that's more optimal than the default dotnet impl.

This optimization applies to all existing `CompositeKey`'s provided they meet the criteria for the fast path generation.