### PR TITLE
feat: Fast path `Format` generation for string properties

### DIFF
--- a/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeyTests.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeyTests.cs
@@ -263,7 +263,7 @@ public static class PrimaryKeyTests
         string result = primaryKey.ToString();
 
         result.Should().NotBeNull();
-        result.Should().Be($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.AnotherGuid}");
+        result.Should().Be($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.StringValue}");
     }
 
     [Theory, AutoData]
@@ -273,7 +273,7 @@ public static class PrimaryKeyTests
         string result = primaryKey.ToPartitionKeyString();
 
         result.Should().NotBeNull();
-        result.Should().Be($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.AnotherGuid}");
+        result.Should().Be($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.StringValue}");
     }
 
     #endregion

--- a/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeys.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeys.cs
@@ -18,8 +18,8 @@ public sealed partial record MixedTypePrimaryKey(Guid GuidValue, int IntValue, s
 [CompositeKey("ConstantValue#{DynamicValue}@ConstantStringAtEndOfKey")]
 public sealed partial record PrimaryKeyWithConstants(Guid DynamicValue);
 
-[CompositeKey("{GuidValue}#Constant#{EnumValue}@{AnotherGuid}")]
-public sealed partial record PrimaryKeyWithFastPathFormatting(Guid GuidValue, PrimaryKeyWithFastPathFormatting.EnumType EnumValue, Guid AnotherGuid)
+[CompositeKey("{GuidValue}#Constant#{EnumValue}@{StringValue}")]
+public sealed partial record PrimaryKeyWithFastPathFormatting(Guid GuidValue, PrimaryKeyWithFastPathFormatting.EnumType EnumValue, string StringValue)
 {
     public enum EnumType { One, Two, Three, Four, Five, Six, Seven, Eight, Nine };
 }


### PR DESCRIPTION
Adds a capability into the generator to optimize the usage of Strings in `Format` code generation.

Now instead of falling back to using a string interpolation we check the length of the string ahead of time and generate a more optimal formatting method.

This optimization applies to all existing `CompositeKey`'s provided they meet the updated criteria for the fast path generation.