### PR TITLE
test: Replace `FluentAssertions` with `Shouldly`

### DIFF
--- a/src/CompositeKey.SourceGeneration.FunctionalTests/CompositeKey.SourceGeneration.FunctionalTests.csproj
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/CompositeKey.SourceGeneration.FunctionalTests.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Using Include="Shouldly" />
         <Using Include="Xunit" />
     </ItemGroup>
 
@@ -20,8 +21,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>

--- a/src/CompositeKey.SourceGeneration.FunctionalTests/CompositePrimaryKeyTests.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/CompositePrimaryKeyTests.cs
@@ -1,5 +1,4 @@
 ﻿using AutoFixture.Xunit2;
-using FluentAssertions;
 
 namespace CompositeKey.SourceGeneration.FunctionalTests;
 
@@ -10,8 +9,8 @@ public static class CompositePrimaryKeyTests
     {
         var result = CompositePrimaryKey.Parse(compositeKey.ToString());
 
-        result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(compositeKey);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(compositeKey);
     }
 
     [Theory, AutoData]
@@ -21,8 +20,8 @@ public static class CompositePrimaryKeyTests
 
         string result = compositeKey.ToString();
 
-        result.Should().NotBeNullOrEmpty();
-        result.Should().Be($"{guidValue}#{decimalValue}|Constant~{enumValue}@{stringValue}");
+        result.ShouldNotBeNullOrEmpty();
+        result.ShouldBe($"{guidValue}#{decimalValue}|Constant~{enumValue}@{stringValue}");
     }
 
     [Theory, AutoData]
@@ -32,8 +31,8 @@ public static class CompositePrimaryKeyTests
 
         string result = compositeKey.ToPartitionKeyString();
 
-        result.Should().NotBeNullOrEmpty();
-        result.Should().Be($"{guidValue}#{decimalValue}");
+        result.ShouldNotBeNullOrEmpty();
+        result.ShouldBe($"{guidValue}#{decimalValue}");
     }
 
     [Theory, AutoData]
@@ -43,8 +42,8 @@ public static class CompositePrimaryKeyTests
 
         string result = compositeKey.ToSortKeyString();
 
-        result.Should().NotBeNullOrEmpty();
-        result.Should().Be($"Constant~{enumValue}@{stringValue}");
+        result.ShouldNotBeNullOrEmpty();
+        result.ShouldBe($"Constant~{enumValue}@{stringValue}");
     }
 
     [Theory, AutoData]
@@ -54,18 +53,18 @@ public static class CompositePrimaryKeyTests
 
         var result = CompositePrimaryKey.Parse($"{guidValue}#{decimalValue}|Constant~{enumValue}@{stringValue}");
 
-        result.Should().NotBeNull();
-        result.GuidValue.Should().Be(guidValue);
-        result.DecimalValue.Should().Be(decimalValue);
-        result.EnumValue.Should().Be(enumValue);
-        result.StringValue.Should().Be(stringValue);
+        result.ShouldNotBeNull();
+        result.GuidValue.ShouldBe(guidValue);
+        result.DecimalValue.ShouldBe(decimalValue);
+        result.EnumValue.ShouldBe(enumValue);
+        result.StringValue.ShouldBe(stringValue);
     }
 
     [Theory, MemberData(nameof(CompositePrimaryKey_InvalidPrimaryKeys))]
     public static void CompositePrimaryKey_Parse_WithInvalidPrimaryKey_ShouldThrowFormatException(string primaryKey)
     {
         var act = () => CompositePrimaryKey.Parse(primaryKey);
-        act.Should().Throw<FormatException>();
+        act.ShouldThrow<FormatException>();
     }
 
     [Theory, AutoData]
@@ -75,18 +74,18 @@ public static class CompositePrimaryKeyTests
 
         var result = CompositePrimaryKey.Parse($"{guidValue}#{decimalValue}", $"Constant~{enumValue}@{stringValue}");
 
-        result.Should().NotBeNull();
-        result.GuidValue.Should().Be(guidValue);
-        result.DecimalValue.Should().Be(decimalValue);
-        result.EnumValue.Should().Be(enumValue);
-        result.StringValue.Should().Be(stringValue);
+        result.ShouldNotBeNull();
+        result.GuidValue.ShouldBe(guidValue);
+        result.DecimalValue.ShouldBe(decimalValue);
+        result.EnumValue.ShouldBe(enumValue);
+        result.StringValue.ShouldBe(stringValue);
     }
 
     [Theory, MemberData(nameof(CompositePrimaryKey_InvalidPartitionKeyAndSortKeys))]
     public static void CompositePrimaryKey_Parse_WithInvalidPartitionKeyAndSortKey_ShouldThrowFormatException(string partitionKey, string sortKey)
     {
         var act = () => CompositePrimaryKey.Parse(partitionKey, sortKey);
-        act.Should().Throw<FormatException>();
+        act.ShouldThrow<FormatException>();
     }
 
     [Theory, AutoData]
@@ -94,21 +93,21 @@ public static class CompositePrimaryKeyTests
     {
         (var guidValue, decimal decimalValue, var enumValue, string stringValue) = compositeKey;
 
-        CompositePrimaryKey.TryParse($"{guidValue}#{decimalValue}|Constant~{enumValue}@{stringValue}", out var result).Should().BeTrue();
+        CompositePrimaryKey.TryParse($"{guidValue}#{decimalValue}|Constant~{enumValue}@{stringValue}", out var result).ShouldBeTrue();
 
-        result.Should().NotBeNull();
-        result!.GuidValue.Should().Be(guidValue);
-        result.DecimalValue.Should().Be(decimalValue);
-        result.EnumValue.Should().Be(enumValue);
-        result.StringValue.Should().Be(stringValue);
+        result.ShouldNotBeNull();
+        result.GuidValue.ShouldBe(guidValue);
+        result.DecimalValue.ShouldBe(decimalValue);
+        result.EnumValue.ShouldBe(enumValue);
+        result.StringValue.ShouldBe(stringValue);
     }
 
     [Theory, MemberData(nameof(CompositePrimaryKey_InvalidPrimaryKeys))]
     public static void CompositePrimaryKey_TryParse_WithInvalidPrimaryKey_ShouldThrowFormatException(string primaryKey)
     {
-        CompositePrimaryKey.TryParse(primaryKey, out var result).Should().BeFalse();
+        CompositePrimaryKey.TryParse(primaryKey, out var result).ShouldBeFalse();
 
-        result.Should().BeNull();
+        result.ShouldBeNull();
     }
 
     [Theory, AutoData]
@@ -116,21 +115,21 @@ public static class CompositePrimaryKeyTests
     {
         (var guidValue, decimal decimalValue, var enumValue, string stringValue) = compositeKey;
 
-        CompositePrimaryKey.TryParse($"{guidValue}#{decimalValue}", $"Constant~{enumValue}@{stringValue}", out var result).Should().BeTrue();
+        CompositePrimaryKey.TryParse($"{guidValue}#{decimalValue}", $"Constant~{enumValue}@{stringValue}", out var result).ShouldBeTrue();
 
-        result.Should().NotBeNull();
-        result!.GuidValue.Should().Be(guidValue);
-        result.DecimalValue.Should().Be(decimalValue);
-        result.EnumValue.Should().Be(enumValue);
-        result.StringValue.Should().Be(stringValue);
+        result.ShouldNotBeNull();
+        result.GuidValue.ShouldBe(guidValue);
+        result.DecimalValue.ShouldBe(decimalValue);
+        result.EnumValue.ShouldBe(enumValue);
+        result.StringValue.ShouldBe(stringValue);
     }
 
     [Theory, MemberData(nameof(CompositePrimaryKey_InvalidPartitionKeyAndSortKeys))]
     public static void CompositePrimaryKey_TryParse_WithInvalidPartitionKeyAndSortKey_ShouldThrowFormatException(string partitionKey, string sortKey)
     {
-        CompositePrimaryKey.TryParse(partitionKey, sortKey, out var result).Should().BeFalse();
+        CompositePrimaryKey.TryParse(partitionKey, sortKey, out var result).ShouldBeFalse();
 
-        result.Should().BeNull();
+        result.ShouldBeNull();
     }
 
     public static object[][] CompositePrimaryKey_InvalidPrimaryKeys() =>

--- a/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeyTests.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/PrimaryKeyTests.cs
@@ -1,5 +1,4 @@
 ﻿using AutoFixture.Xunit2;
-using FluentAssertions;
 
 namespace CompositeKey.SourceGeneration.FunctionalTests;
 
@@ -12,8 +11,8 @@ public static class PrimaryKeyTests
     {
         var result = GuidOnlyPrimaryKey.Parse(primaryKey.ToString());
 
-        result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(primaryKey);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(primaryKey);
     }
 
     [Theory, AutoData]
@@ -21,8 +20,8 @@ public static class PrimaryKeyTests
     {
         string result = primaryKey.ToString();
 
-        result.Should().NotBeNullOrEmpty();
-        result.Should().Be($"{primaryKey.First}#{primaryKey.Second}");
+        result.ShouldNotBeNullOrEmpty();
+        result.ShouldBe($"{primaryKey.First}#{primaryKey.Second}");
     }
 
     [Theory, AutoData]
@@ -30,8 +29,8 @@ public static class PrimaryKeyTests
     {
         string result = primaryKey.ToPartitionKeyString();
 
-        result.Should().NotBeNullOrEmpty();
-        result.Should().Be($"{primaryKey.First}#{primaryKey.Second}");
+        result.ShouldNotBeNullOrEmpty();
+        result.ShouldBe($"{primaryKey.First}#{primaryKey.Second}");
     }
 
     [Theory, AutoData]
@@ -39,34 +38,34 @@ public static class PrimaryKeyTests
     {
         var result = GuidOnlyPrimaryKey.Parse($"{first}#{second}");
 
-        result.Should().NotBeNull();
-        result.First.Should().Be(first);
-        result.Second.Should().Be(second);
+        result.ShouldNotBeNull();
+        result.First.ShouldBe(first);
+        result.Second.ShouldBe(second);
     }
 
     [Theory, MemberData(nameof(GuidOnlyPrimaryKey_InvalidInputs))]
     public static void GuidOnlyPrimaryKey_Parse_WithInvalidKey_ShouldThrowFormatException(string input)
     {
         var act = () => GuidOnlyPrimaryKey.Parse(input);
-        act.Should().Throw<FormatException>();
+        act.ShouldThrow<FormatException>();
     }
 
     [Theory, AutoData]
     public static void GuidOnlyPrimaryKey_TryParse_WithValidKey_ShouldReturnTrueAndOutputCorrectlyParsedRecord(Guid first, Guid second)
     {
-        GuidOnlyPrimaryKey.TryParse($"{first}#{second}", out var result).Should().BeTrue();
+        GuidOnlyPrimaryKey.TryParse($"{first}#{second}", out var result).ShouldBeTrue();
 
-        result.Should().NotBeNull();
-        result!.First.Should().Be(first);
-        result.Second.Should().Be(second);
+        result.ShouldNotBeNull();
+        result.First.ShouldBe(first);
+        result.Second.ShouldBe(second);
     }
 
     [Theory, MemberData(nameof(GuidOnlyPrimaryKey_InvalidInputs))]
     public static void GuidOnlyPrimaryKey_TryParse_WithInvalidKey_ShouldReturnFalse(string input)
     {
-        GuidOnlyPrimaryKey.TryParse(input, out var result).Should().BeFalse();
+        GuidOnlyPrimaryKey.TryParse(input, out var result).ShouldBeFalse();
 
-        result.Should().BeNull();
+        result.ShouldBeNull();
     }
 
     public static object[][] GuidOnlyPrimaryKey_InvalidInputs() =>
@@ -88,8 +87,8 @@ public static class PrimaryKeyTests
     {
         var result = MixedTypePrimaryKey.Parse(primaryKey.ToString());
 
-        result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(primaryKey);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(primaryKey);
     }
 
     [Theory, AutoData]
@@ -97,8 +96,8 @@ public static class PrimaryKeyTests
     {
         string result = primaryKey.ToString();
 
-        result.Should().NotBeNull();
-        result.Should().Be($"{primaryKey.GuidValue}#{primaryKey.IntValue}~{primaryKey.StringValue}#{primaryKey.EnumValue}");
+        result.ShouldNotBeNull();
+        result.ShouldBe($"{primaryKey.GuidValue}#{primaryKey.IntValue}~{primaryKey.StringValue}#{primaryKey.EnumValue}");
     }
 
     [Theory, AutoData]
@@ -106,8 +105,8 @@ public static class PrimaryKeyTests
     {
         string result = primaryKey.ToPartitionKeyString();
 
-        result.Should().NotBeNull();
-        result.Should().Be($"{primaryKey.GuidValue}#{primaryKey.IntValue}~{primaryKey.StringValue}#{primaryKey.EnumValue}");
+        result.ShouldNotBeNull();
+        result.ShouldBe($"{primaryKey.GuidValue}#{primaryKey.IntValue}~{primaryKey.StringValue}#{primaryKey.EnumValue}");
     }
 
     [Theory, AutoData]
@@ -116,39 +115,39 @@ public static class PrimaryKeyTests
     {
         var result = MixedTypePrimaryKey.Parse($"{guidValue}#{intValue}~{stringValue}#{enumValue}");
 
-        result.Should().NotBeNull();
-        result.GuidValue.Should().Be(guidValue);
-        result.IntValue.Should().Be(intValue);
-        result.StringValue.Should().Be(stringValue);
-        result.EnumValue.Should().Be(enumValue);
+        result.ShouldNotBeNull();
+        result.GuidValue.ShouldBe(guidValue);
+        result.IntValue.ShouldBe(intValue);
+        result.StringValue.ShouldBe(stringValue);
+        result.EnumValue.ShouldBe(enumValue);
     }
 
     [Theory, MemberData(nameof(MixedTypePrimaryKey_InvalidInputs))]
     public static void MixedTypePrimaryKey_Parse_WithInvalidKey_ShouldThrowFormatException(string input)
     {
         var act = () => MixedTypePrimaryKey.Parse(input);
-        act.Should().Throw<FormatException>();
+        act.ShouldThrow<FormatException>();
     }
 
     [Theory, AutoData]
     public static void MixedTypePrimaryKey_TryParse_WithValidKey_ShouldReturnTrueAndOutputCorrectlyParsedRecord(
         Guid guidValue, int intValue, string stringValue, MixedTypePrimaryKey.EnumType enumValue)
     {
-        MixedTypePrimaryKey.TryParse($"{guidValue}#{intValue}~{stringValue}#{enumValue}", out var result).Should().BeTrue();
+        MixedTypePrimaryKey.TryParse($"{guidValue}#{intValue}~{stringValue}#{enumValue}", out var result).ShouldBeTrue();
 
-        result.Should().NotBeNull();
-        result!.GuidValue.Should().Be(guidValue);
-        result.IntValue.Should().Be(intValue);
-        result.StringValue.Should().Be(stringValue);
-        result.EnumValue.Should().Be(enumValue);
+        result.ShouldNotBeNull();
+        result.GuidValue.ShouldBe(guidValue);
+        result.IntValue.ShouldBe(intValue);
+        result.StringValue.ShouldBe(stringValue);
+        result.EnumValue.ShouldBe(enumValue);
     }
 
     [Theory, MemberData(nameof(MixedTypePrimaryKey_InvalidInputs))]
     public static void MixedTypePrimaryKey_TryParse_WithInvalidKey_ShouldReturnFalse(string input)
     {
-        MixedTypePrimaryKey.TryParse(input, out var result).Should().BeFalse();
+        MixedTypePrimaryKey.TryParse(input, out var result).ShouldBeFalse();
 
-        result.Should().BeNull();
+        result.ShouldBeNull();
     }
 
     public static object[][] MixedTypePrimaryKey_InvalidInputs() =>
@@ -174,8 +173,8 @@ public static class PrimaryKeyTests
     {
         var result = PrimaryKeyWithConstants.Parse(primaryKey.ToString());
 
-        result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(primaryKey);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(primaryKey);
     }
 
     [Theory, AutoData]
@@ -183,8 +182,8 @@ public static class PrimaryKeyTests
     {
         string result = primaryKey.ToString();
 
-        result.Should().NotBeNull();
-        result.Should().Be($"ConstantValue#{primaryKey.DynamicValue}@ConstantStringAtEndOfKey");
+        result.ShouldNotBeNull();
+        result.ShouldBe($"ConstantValue#{primaryKey.DynamicValue}@ConstantStringAtEndOfKey");
     }
 
     [Theory, AutoData]
@@ -192,8 +191,8 @@ public static class PrimaryKeyTests
     {
         string result = primaryKey.ToPartitionKeyString();
 
-        result.Should().NotBeNull();
-        result.Should().Be($"ConstantValue#{primaryKey.DynamicValue}@ConstantStringAtEndOfKey");
+        result.ShouldNotBeNull();
+        result.ShouldBe($"ConstantValue#{primaryKey.DynamicValue}@ConstantStringAtEndOfKey");
     }
 
     [Theory, AutoData]
@@ -202,33 +201,33 @@ public static class PrimaryKeyTests
     {
         var result = PrimaryKeyWithConstants.Parse($"ConstantValue#{dynamicValue}@ConstantStringAtEndOfKey");
 
-        result.Should().NotBeNull();
-        result.DynamicValue.Should().Be(dynamicValue);
+        result.ShouldNotBeNull();
+        result.DynamicValue.ShouldBe(dynamicValue);
     }
 
     [Theory, MemberData(nameof(PrimaryKeyWithConstants_InvalidInputs))]
     public static void PrimaryKeyWithConstants_Parse_WithInvalidKey_ShouldThrowFormatException(string input)
     {
         var act = () => MixedTypePrimaryKey.Parse(input);
-        act.Should().Throw<FormatException>();
+        act.ShouldThrow<FormatException>();
     }
 
     [Theory, AutoData]
     public static void PrimaryKeyWithConstants_TryParse_WithValidKey_ShouldReturnTrueAndOutputCorrectlyParsedRecord(
         Guid dynamicValue)
     {
-        PrimaryKeyWithConstants.TryParse($"ConstantValue#{dynamicValue}@ConstantStringAtEndOfKey", out var result).Should().BeTrue();
+        PrimaryKeyWithConstants.TryParse($"ConstantValue#{dynamicValue}@ConstantStringAtEndOfKey", out var result).ShouldBeTrue();
 
-        result.Should().NotBeNull();
-        result!.DynamicValue.Should().Be(dynamicValue);
+        result.ShouldNotBeNull();
+        result.DynamicValue.ShouldBe(dynamicValue);
     }
 
     [Theory, MemberData(nameof(PrimaryKeyWithConstants_InvalidInputs))]
     public static void PrimaryKeyWithConstants_TryParse_WithInvalidKey_ShouldReturnFalse(string input)
     {
-        MixedTypePrimaryKey.TryParse(input, out var result).Should().BeFalse();
+        MixedTypePrimaryKey.TryParse(input, out var result).ShouldBeFalse();
 
-        result.Should().BeNull();
+        result.ShouldBeNull();
     }
 
     public static object[][] PrimaryKeyWithConstants_InvalidInputs() =>
@@ -252,8 +251,8 @@ public static class PrimaryKeyTests
     {
         var result = PrimaryKeyWithFastPathFormatting.Parse(primaryKey.ToString());
 
-        result.Should().NotBeNull();
-        result.Should().BeEquivalentTo(primaryKey);
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(primaryKey);
     }
 
     [Theory, AutoData]
@@ -262,8 +261,8 @@ public static class PrimaryKeyTests
     {
         string result = primaryKey.ToString();
 
-        result.Should().NotBeNull();
-        result.Should().Be($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.StringValue}");
+        result.ShouldNotBeNull();
+        result.ShouldBe($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.StringValue}");
     }
 
     [Theory, AutoData]
@@ -272,8 +271,8 @@ public static class PrimaryKeyTests
     {
         string result = primaryKey.ToPartitionKeyString();
 
-        result.Should().NotBeNull();
-        result.Should().Be($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.StringValue}");
+        result.ShouldNotBeNull();
+        result.ShouldBe($"{primaryKey.GuidValue}#Constant#{primaryKey.EnumValue}@{primaryKey.StringValue}");
     }
 
     #endregion

--- a/src/CompositeKey.SourceGeneration.FunctionalTests/packages.lock.json
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/packages.lock.json
@@ -24,15 +24,6 @@
         "resolved": "1.2.25",
         "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
       },
-      "FluentAssertions": {
-        "type": "Direct",
-        "requested": "[6.12.2, )",
-        "resolved": "6.12.2",
-        "contentHash": "8YE+xJmT8wgzEpFuzJ4S62oFhEL/AKouMz1RWPEMEUhy9H11aRQlGIWcHurH5BEy7tbF6gb0CJrs0wOw/AtDcQ==",
-        "dependencies": {
-          "System.Configuration.ConfigurationManager": "4.4.0"
-        }
-      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.11.1, )",
@@ -41,6 +32,16 @@
         "dependencies": {
           "Microsoft.CodeCoverage": "17.11.1",
           "Microsoft.TestPlatform.TestHost": "17.11.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.2.1, )",
+        "resolved": "4.2.1",
+        "contentHash": "dKAKiSuhLKqD2TXwLKtqNg1nwzJcIKOOMncZjk9LYe4W+h+SCftpWdxwR79YZUIHMH+3Vu9s0s0UHNrgICLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
         }
       },
       "xunit": {
@@ -68,6 +69,20 @@
           "Fare": "[2.1.1, 3.0.0)",
           "System.ComponentModel.Annotations": "4.3.0"
         }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
       },
       "Fare": {
         "type": "Transitive",
@@ -302,6 +317,11 @@
           "System.Threading": "4.3.0"
         }
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
       "System.Collections": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -353,14 +373,6 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Text.RegularExpressions": "4.3.0",
           "System.Threading": "4.3.0"
-        }
-      },
-      "System.Configuration.ConfigurationManager": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "gWwQv/Ug1qWJmHCmN17nAbxJYmQBM/E94QxKLksvUiiKB1Ld3Sc/eK1lgmbSjDFxkQhVuayI/cGFZhpBSodLrg==",
-        "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "4.4.0"
         }
       },
       "System.Console": {
@@ -558,6 +570,14 @@
           "System.Runtime": "4.3.0",
           "System.Runtime.Extensions": "4.3.0",
           "System.Threading": "4.3.0"
+        }
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
         }
       },
       "System.Net.Http": {
@@ -899,11 +919,6 @@
           "System.Threading": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
         }
-      },
-      "System.Security.Cryptography.ProtectedData": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
       },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Transitive",
@@ -1113,15 +1128,6 @@
         "resolved": "1.2.25",
         "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
       },
-      "FluentAssertions": {
-        "type": "Direct",
-        "requested": "[6.12.2, )",
-        "resolved": "6.12.2",
-        "contentHash": "8YE+xJmT8wgzEpFuzJ4S62oFhEL/AKouMz1RWPEMEUhy9H11aRQlGIWcHurH5BEy7tbF6gb0CJrs0wOw/AtDcQ==",
-        "dependencies": {
-          "System.Configuration.ConfigurationManager": "4.4.0"
-        }
-      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.11.1, )",
@@ -1130,6 +1136,16 @@
         "dependencies": {
           "Microsoft.CodeCoverage": "17.11.1",
           "Microsoft.TestPlatform.TestHost": "17.11.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.2.1, )",
+        "resolved": "4.2.1",
+        "contentHash": "dKAKiSuhLKqD2TXwLKtqNg1nwzJcIKOOMncZjk9LYe4W+h+SCftpWdxwR79YZUIHMH+3Vu9s0s0UHNrgICLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
         }
       },
       "xunit": {
@@ -1157,6 +1173,20 @@
           "Fare": "[2.1.1, 3.0.0)",
           "System.ComponentModel.Annotations": "4.3.0"
         }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
       },
       "Fare": {
         "type": "Transitive",
@@ -1391,6 +1421,11 @@
           "System.Threading": "4.3.0"
         }
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
       "System.Collections": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1442,14 +1477,6 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Text.RegularExpressions": "4.3.0",
           "System.Threading": "4.3.0"
-        }
-      },
-      "System.Configuration.ConfigurationManager": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "gWwQv/Ug1qWJmHCmN17nAbxJYmQBM/E94QxKLksvUiiKB1Ld3Sc/eK1lgmbSjDFxkQhVuayI/cGFZhpBSodLrg==",
-        "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "4.4.0"
         }
       },
       "System.Console": {
@@ -1647,6 +1674,14 @@
           "System.Runtime": "4.3.0",
           "System.Runtime.Extensions": "4.3.0",
           "System.Threading": "4.3.0"
+        }
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
         }
       },
       "System.Net.Http": {
@@ -1988,11 +2023,6 @@
           "System.Threading": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
         }
-      },
-      "System.Security.Cryptography.ProtectedData": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
       },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Transitive",

--- a/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Reflection;
 using CompositeKey.SourceGeneration.Model;
-using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
@@ -75,8 +74,8 @@ public static class CompilationHelper
 
         if (!disableDiagnosticValidation)
         {
-            outputCompilation.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).Should().BeEmpty();
-            diagnostics.Where(d => d.Severity > DiagnosticSeverity.Info).Should().BeEmpty();
+            outputCompilation.GetDiagnostics().Where(d => d.Severity > DiagnosticSeverity.Info).ShouldBeEmpty();
+            diagnostics.Where(d => d.Severity > DiagnosticSeverity.Info).ShouldBeEmpty();
         }
 
         return new SourceGeneratorResult()

--- a/src/CompositeKey.SourceGeneration.UnitTests/CompositeKey.SourceGeneration.UnitTests.csproj
+++ b/src/CompositeKey.SourceGeneration.UnitTests/CompositeKey.SourceGeneration.UnitTests.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Using Include="Shouldly" />
         <Using Include="Xunit" />
     </ItemGroup>
 
@@ -21,8 +22,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Shouldly" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>

--- a/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorIncrementalTests.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorIncrementalTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Reflection;
-using FluentAssertions;
 using Microsoft.CodeAnalysis;
 
 namespace CompositeKey.SourceGeneration.UnitTests;
@@ -13,18 +12,18 @@ public static class SourceGeneratorIncrementalTests
         var firstResult = CompilationHelper.RunSourceGenerator(factory(), disableDiagnosticValidation: true);
         var secondResult = CompilationHelper.RunSourceGenerator(factory(), disableDiagnosticValidation: true);
 
-        firstResult.GenerationSpecs.Length.Should().Be(secondResult.GenerationSpecs.Length);
+        firstResult.GenerationSpecs.Length.ShouldBe(secondResult.GenerationSpecs.Length);
 
         for (int i = 0; i < firstResult.GenerationSpecs.Length; i++)
         {
             var firstGenerationSpec = firstResult.GenerationSpecs[i];
             var secondGenerationSpec = secondResult.GenerationSpecs[i];
 
-            firstGenerationSpec.Should().NotBeSameAs(secondGenerationSpec);
+            firstGenerationSpec.ShouldNotBeSameAs(secondGenerationSpec);
             AssertStructurallyEqual(firstGenerationSpec, secondGenerationSpec);
 
-            firstGenerationSpec.Should().Be(secondGenerationSpec);
-            firstGenerationSpec.GetHashCode().Should().Be(secondGenerationSpec.GetHashCode());
+            firstGenerationSpec.ShouldBe(secondGenerationSpec);
+            firstGenerationSpec.GetHashCode().ShouldBe(secondGenerationSpec.GetHashCode());
         }
     }
 
@@ -58,17 +57,17 @@ public static class SourceGeneratorIncrementalTests
         var firstResult = CompilationHelper.RunSourceGenerator(CompilationHelper.CreateCompilation(FirstSource));
         var secondResult = CompilationHelper.RunSourceGenerator(CompilationHelper.CreateCompilation(SecondSource));
 
-        firstResult.GenerationSpecs.Should().HaveCount(1);
+        firstResult.GenerationSpecs.ShouldHaveSingleItem();
         var firstGenerationSpec = firstResult.GenerationSpecs[0];
 
-        secondResult.GenerationSpecs.Should().HaveCount(1);
+        secondResult.GenerationSpecs.ShouldHaveSingleItem();
         var secondGenerationSpec = secondResult.GenerationSpecs[0];
 
-        firstGenerationSpec.Should().NotBeSameAs(secondGenerationSpec);
+        firstGenerationSpec.ShouldNotBeSameAs(secondGenerationSpec);
         AssertStructurallyEqual(firstGenerationSpec, secondGenerationSpec);
 
-        firstGenerationSpec.Should().Be(secondGenerationSpec);
-        firstGenerationSpec.GetHashCode().Should().Be(secondGenerationSpec.GetHashCode());
+        firstGenerationSpec.ShouldBe(secondGenerationSpec);
+        firstGenerationSpec.GetHashCode().ShouldBe(secondGenerationSpec.GetHashCode());
     }
 
     [Fact]
@@ -97,15 +96,15 @@ public static class SourceGeneratorIncrementalTests
         var firstResult = CompilationHelper.RunSourceGenerator(CompilationHelper.CreateCompilation(FirstSource));
         var secondResult = CompilationHelper.RunSourceGenerator(CompilationHelper.CreateCompilation(SecondSource));
 
-        firstResult.GenerationSpecs.Should().HaveCount(1);
+        firstResult.GenerationSpecs.ShouldHaveSingleItem();
         var firstGenerationSpec = firstResult.GenerationSpecs[0];
 
-        secondResult.GenerationSpecs.Should().HaveCount(1);
+        secondResult.GenerationSpecs.ShouldHaveSingleItem();
         var secondGenerationSpec = secondResult.GenerationSpecs[0];
 
-        firstGenerationSpec.Should().NotBeSameAs(secondGenerationSpec);
-        firstGenerationSpec.Should().NotBe(secondGenerationSpec);
-        firstGenerationSpec.GetHashCode().Should().NotBe(secondGenerationSpec.GetHashCode());
+        firstGenerationSpec.ShouldNotBeSameAs(secondGenerationSpec);
+        firstGenerationSpec.ShouldNotBe(secondGenerationSpec);
+        firstGenerationSpec.GetHashCode().ShouldNotBe(secondGenerationSpec.GetHashCode());
     }
 
     [Theory, MemberData(nameof(GetCompilationHelperFactories))]
@@ -122,7 +121,7 @@ public static class SourceGeneratorIncrementalTests
             if (node is null || !visited.Add(node))
                 return;
 
-            (node is Compilation or ISymbol).Should().BeFalse();
+            (node is Compilation or ISymbol).ShouldBeFalse();
 
             var type = node.GetType();
             if (type.IsPrimitive || type.IsEnum || type == typeof(string))
@@ -157,10 +156,10 @@ public static class SourceGeneratorIncrementalTests
             foreach (var step in steps)
             {
                 foreach ((var source, int outputIndex) in step.Inputs)
-                    source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.New);
+                    source.Outputs[outputIndex].Reason.ShouldBe(IncrementalStepRunReason.New);
 
                 foreach (var output in step.Outputs)
-                    output.Reason.Should().Be(IncrementalStepRunReason.New);
+                    output.Reason.ShouldBe(IncrementalStepRunReason.New);
             }
         }
 
@@ -171,20 +170,20 @@ public static class SourceGeneratorIncrementalTests
         var newSteps = GetGeneratorRunSteps(result);
         if (steps != null)
         {
-            newSteps.Should().NotBeNull();
+            newSteps.ShouldNotBeNull();
 
-            foreach (var step in newSteps!)
+            foreach (var step in newSteps)
             {
                 foreach ((var source, int outputIndex) in step.Inputs)
-                    source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.Cached);
+                    source.Outputs[outputIndex].Reason.ShouldBe(IncrementalStepRunReason.Cached);
 
                 foreach (var output in step.Outputs)
-                    output.Reason.Should().Be(IncrementalStepRunReason.Cached);
+                    output.Reason.ShouldBe(IncrementalStepRunReason.Cached);
             }
         }
         else
         {
-            newSteps.Should().BeNull();
+            newSteps.ShouldBeNull();
         }
 
         return;
@@ -228,10 +227,10 @@ public static class SourceGeneratorIncrementalTests
         foreach (var step in result.TrackedSteps[SourceGenerator.GenerationSpecTrackingName])
         {
             foreach ((var source, int outputIndex) in step.Inputs)
-                source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.New);
+                source.Outputs[outputIndex].Reason.ShouldBe(IncrementalStepRunReason.New);
 
             foreach (var output in step.Outputs)
-                output.Reason.Should().Be(IncrementalStepRunReason.New);
+                output.Reason.ShouldBe(IncrementalStepRunReason.New);
         }
 
         // Execute the generator again with an updated *but equivalent* syntax tree, confirm the output is unchanged
@@ -242,10 +241,10 @@ public static class SourceGeneratorIncrementalTests
         foreach (var step in result.TrackedSteps[SourceGenerator.GenerationSpecTrackingName])
         {
             foreach ((var source, int outputIndex) in step.Inputs)
-                source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.Modified);
+                source.Outputs[outputIndex].Reason.ShouldBe(IncrementalStepRunReason.Modified);
 
             foreach (var output in step.Outputs)
-                output.Reason.Should().Be(IncrementalStepRunReason.Unchanged);
+                output.Reason.ShouldBe(IncrementalStepRunReason.Unchanged);
         }
     }
 
@@ -281,10 +280,10 @@ public static class SourceGeneratorIncrementalTests
         foreach (var step in result.TrackedSteps[SourceGenerator.GenerationSpecTrackingName])
         {
             foreach ((var source, int outputIndex) in step.Inputs)
-                source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.New);
+                source.Outputs[outputIndex].Reason.ShouldBe(IncrementalStepRunReason.New);
 
             foreach (var output in step.Outputs)
-                output.Reason.Should().Be(IncrementalStepRunReason.New);
+                output.Reason.ShouldBe(IncrementalStepRunReason.New);
         }
 
         // Execute the generator again with an updated *but equivalent* syntax tree, confirm the output is unchanged
@@ -295,10 +294,10 @@ public static class SourceGeneratorIncrementalTests
         foreach (var step in result.TrackedSteps[SourceGenerator.GenerationSpecTrackingName])
         {
             foreach ((var source, int outputIndex) in step.Inputs)
-                source.Outputs[outputIndex].Reason.Should().Be(IncrementalStepRunReason.Modified);
+                source.Outputs[outputIndex].Reason.ShouldBe(IncrementalStepRunReason.Modified);
 
             foreach (var output in step.Outputs)
-                output.Reason.Should().Be(IncrementalStepRunReason.Modified);
+                output.Reason.ShouldBe(IncrementalStepRunReason.Modified);
         }
     }
 

--- a/src/CompositeKey.SourceGeneration.UnitTests/packages.lock.json
+++ b/src/CompositeKey.SourceGeneration.UnitTests/packages.lock.json
@@ -14,15 +14,6 @@
         "resolved": "1.2.25",
         "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
       },
-      "FluentAssertions": {
-        "type": "Direct",
-        "requested": "[6.12.2, )",
-        "resolved": "6.12.2",
-        "contentHash": "8YE+xJmT8wgzEpFuzJ4S62oFhEL/AKouMz1RWPEMEUhy9H11aRQlGIWcHurH5BEy7tbF6gb0CJrs0wOw/AtDcQ==",
-        "dependencies": {
-          "System.Configuration.ConfigurationManager": "4.4.0"
-        }
-      },
       "Microsoft.CodeAnalysis": {
         "type": "Direct",
         "requested": "[4.8.0, )",
@@ -43,6 +34,16 @@
           "Microsoft.TestPlatform.TestHost": "17.11.1"
         }
       },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.2.1, )",
+        "resolved": "4.2.1",
+        "contentHash": "dKAKiSuhLKqD2TXwLKtqNg1nwzJcIKOOMncZjk9LYe4W+h+SCftpWdxwR79YZUIHMH+3Vu9s0s0UHNrgICLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.2, )",
@@ -59,6 +60,20 @@
         "requested": "[2.8.2, )",
         "resolved": "2.8.2",
         "contentHash": "vm1tbfXhFmjFMUmS4M0J0ASXz3/U5XvXBa6DOQUL3fEz4Vt6YPhv+ESCarx6M6D+9kJkJYZKCNvJMas1+nVfmQ=="
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -152,6 +167,11 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
       "System.Collections.Immutable": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -205,18 +225,18 @@
           "System.Composition.Runtime": "7.0.0"
         }
       },
-      "System.Configuration.ConfigurationManager": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "gWwQv/Ug1qWJmHCmN17nAbxJYmQBM/E94QxKLksvUiiKB1Ld3Sc/eK1lgmbSjDFxkQhVuayI/cGFZhpBSodLrg==",
-        "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "4.4.0"
-        }
-      },
       "System.IO.Pipelines": {
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "jRn6JYnNPW6xgQazROBLSfpdoczRw694vO5kKvMcNnpXuolEixUyw6IBuBs2Y2mlSX/LdLvyyWmfXhaI3ND1Yg=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -230,11 +250,6 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
-      },
-      "System.Security.Cryptography.ProtectedData": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
       },
       "System.Threading.Channels": {
         "type": "Transitive",
@@ -313,15 +328,6 @@
         "resolved": "1.2.25",
         "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
       },
-      "FluentAssertions": {
-        "type": "Direct",
-        "requested": "[6.12.2, )",
-        "resolved": "6.12.2",
-        "contentHash": "8YE+xJmT8wgzEpFuzJ4S62oFhEL/AKouMz1RWPEMEUhy9H11aRQlGIWcHurH5BEy7tbF6gb0CJrs0wOw/AtDcQ==",
-        "dependencies": {
-          "System.Configuration.ConfigurationManager": "4.4.0"
-        }
-      },
       "Microsoft.CodeAnalysis": {
         "type": "Direct",
         "requested": "[4.8.0, )",
@@ -342,6 +348,16 @@
           "Microsoft.TestPlatform.TestHost": "17.11.1"
         }
       },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.2.1, )",
+        "resolved": "4.2.1",
+        "contentHash": "dKAKiSuhLKqD2TXwLKtqNg1nwzJcIKOOMncZjk9LYe4W+h+SCftpWdxwR79YZUIHMH+3Vu9s0s0UHNrgICLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.2, )",
@@ -358,6 +374,20 @@
         "requested": "[2.8.2, )",
         "resolved": "2.8.2",
         "contentHash": "vm1tbfXhFmjFMUmS4M0J0ASXz3/U5XvXBa6DOQUL3fEz4Vt6YPhv+ESCarx6M6D+9kJkJYZKCNvJMas1+nVfmQ=="
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -451,6 +481,11 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
       "System.Collections.Immutable": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -504,18 +539,18 @@
           "System.Composition.Runtime": "7.0.0"
         }
       },
-      "System.Configuration.ConfigurationManager": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "gWwQv/Ug1qWJmHCmN17nAbxJYmQBM/E94QxKLksvUiiKB1Ld3Sc/eK1lgmbSjDFxkQhVuayI/cGFZhpBSodLrg==",
-        "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "4.4.0"
-        }
-      },
       "System.IO.Pipelines": {
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "jRn6JYnNPW6xgQazROBLSfpdoczRw694vO5kKvMcNnpXuolEixUyw6IBuBs2Y2mlSX/LdLvyyWmfXhaI3ND1Yg=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -529,11 +564,6 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
-      },
-      "System.Security.Cryptography.ProtectedData": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "cJV7ScGW7EhatRsjehfvvYVBvtiSMKgN8bOVI0bQhnF5bU7vnHVIsH49Kva7i7GWaWYvmEzkYVk1TC+gZYBEog=="
       },
       "System.Threading.Channels": {
         "type": "Transitive",

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,9 +21,9 @@
     <ItemGroup>
         <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
         <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-        <PackageVersion Include="FluentAssertions" Version="6.12.2" />
         <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(AnalyzerRoslynVersion)" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageVersion Include="Shouldly" Version="4.2.1" />
         <PackageVersion Include="xunit" Version="2.9.2" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     </ItemGroup>


### PR DESCRIPTION
Due to the upcoming license changes in `FluentAssertions` replacing it with `Shouldly`