### PR TITLE
feat: Handle same property being used twice

### DIFF
--- a/src/CompositeKey.SourceGeneration.FunctionalTests/CompositePrimaryKeyTests.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/CompositePrimaryKeyTests.cs
@@ -4,6 +4,8 @@ namespace CompositeKey.SourceGeneration.FunctionalTests;
 
 public static class CompositePrimaryKeyTests
 {
+    #region CompositePrimaryKey
+
     [Theory, AutoData]
     public static void CompositePrimaryKey_RoundTripToStringAndParse_ShouldResultInEquivalentKey(CompositePrimaryKey compositeKey)
     {
@@ -161,4 +163,81 @@ public static class CompositePrimaryKeyTests
         ["eccd98c4-d484-4429-896d-8fcdd77c6327#123", "Constant~Three@"],
         ["eccd98c4-d484-4429-896d-8fcdd77c6327#123", "Constant~Three@String~Extra"]
     ];
+
+    #endregion
+
+    #region CompositePrimaryKeyWithSamePropertyUsedTwice
+
+    [Theory, AutoData]
+    public static void CompositePrimaryKeyWithSamePropertyUsedTwice_RoundTripToStringAndParse_ShouldResultInEquivalentKey(CompositePrimaryKeyWithSamePropertyUsedTwice compositeKey)
+    {
+        var result = CompositePrimaryKeyWithSamePropertyUsedTwice.Parse(compositeKey.ToString());
+
+        result.ShouldNotBeNull();
+        result.ShouldBeEquivalentTo(compositeKey);
+    }
+
+    [Theory, AutoData]
+    public static void CompositePrimaryKeyWithSamePropertyUsedTwice_ToString_ShouldReturnCorrectlyFormattedString(CompositePrimaryKeyWithSamePropertyUsedTwice compositeKey)
+    {
+        var id = compositeKey.Id;
+
+        string result = compositeKey.ToString();
+
+        result.ShouldNotBeNullOrEmpty();
+        result.ShouldBe($"{id}#{id}");
+    }
+
+    [Theory, AutoData]
+    public static void CompositePrimaryKeyWithSamePropertyUsedTwice_Parse_WithValidPrimaryKey_ShouldReturnCorrectlyParsedRecord(CompositePrimaryKeyWithSamePropertyUsedTwice compositeKey)
+    {
+        var id = compositeKey.Id;
+
+        var result = CompositePrimaryKeyWithSamePropertyUsedTwice.Parse($"{id}#{id}");
+
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(id);
+    }
+
+    [Theory, MemberData(nameof(CompositePrimaryKeyWithSamePropertyUsedTwice_InvalidPrimaryKeys))]
+    public static void CompositePrimaryKeyWithSamePropertyUsedTwice_Parse_WithInvalidPrimaryKey_ShouldThrowFormatException(string primaryKey)
+    {
+        var act = () => CompositePrimaryKeyWithSamePropertyUsedTwice.Parse(primaryKey);
+        act.ShouldThrow<FormatException>();
+    }
+
+    [Theory, AutoData]
+    public static void CompositePrimaryKeyWithSamePropertyUsedTwice_TryParse_WithValidPrimaryKey_ShouldReturnTrueAndOutputCorrectlyParsedRecord(CompositePrimaryKeyWithSamePropertyUsedTwice compositeKey)
+    {
+        var id = compositeKey.Id;
+
+        CompositePrimaryKeyWithSamePropertyUsedTwice.TryParse($"{id}#{id}", out var result).ShouldBeTrue();
+
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(id);
+    }
+
+    [Theory, MemberData(nameof(CompositePrimaryKeyWithSamePropertyUsedTwice_InvalidPrimaryKeys))]
+    public static void CompositePrimaryKeyWithSamePropertyUsedTwice_TryParse_WithInvalidPrimaryKey_ShouldReturnFalse(string primaryKey)
+    {
+        CompositePrimaryKeyWithSamePropertyUsedTwice.TryParse(primaryKey, out var result).ShouldBeFalse();
+
+        result.ShouldBeNull();
+    }
+
+    public static object[][] CompositePrimaryKeyWithSamePropertyUsedTwice_InvalidPrimaryKeys() =>
+    [
+        ["a"],
+        ["a#b"],
+        ["#"],
+        ["a#"],
+        ["#a"],
+        [""],
+        ["invalid-guid#invalid-guid"],
+        ["eccd98c4-d484-4429-896d-8fcdd77c6327#different-guid"],
+        ["eccd98c4-d484-4429-896d-8fcdd77c6327#eccd98c4-d484-4429-896d-8fcdd77c6328"],
+        ["eccd98c4-d484-4429-896d-8fcdd77c6327#eccd98c4-d484-4429-896d-8fcdd77c6327#extra"]
+    ];
+
+    #endregion
 }

--- a/src/CompositeKey.SourceGeneration.FunctionalTests/CompositePrimaryKeys.cs
+++ b/src/CompositeKey.SourceGeneration.FunctionalTests/CompositePrimaryKeys.cs
@@ -9,3 +9,6 @@ public sealed partial record CompositePrimaryKey(
 {
     public enum EnumType { One, Two, Three };
 }
+
+[CompositeKey("{Id}#{Id}", PrimaryKeySeparator = '#')]
+public sealed partial record CompositePrimaryKeyWithSamePropertyUsedTwice(Guid Id);

--- a/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/CompilationHelper.cs
@@ -317,6 +317,16 @@ public static class CompilationHelper
         }
         """);
 
+    public static Compilation CreateCompilationWithSamePropertyUsedTwice() => CreateCompilation("""
+        using System;
+        using CompositeKey;
+
+        namespace UnitTests;
+
+        [CompositeKey("{Id}|{Id}")]
+        public partial record KeyWithSamePropertyUsedTwice(Guid Id);
+        """);
+
     public record struct DiagnosticData(DiagnosticSeverity Severity, string FilePath, LinePositionSpan LinePositionSpan, string Message)
     {
         public DiagnosticData(DiagnosticSeverity severity, Location location, string message)

--- a/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorTests.cs
+++ b/src/CompositeKey.SourceGeneration.UnitTests/SourceGeneratorTests.cs
@@ -545,4 +545,11 @@ public static class SourceGeneratorTests
 
         CompilationHelper.AssertDiagnostics(expectedDiagnostics, result.Diagnostics);
     }
+
+    [Fact]
+    public static void KeyWithSamePropertyUsedTwice_ShouldSuccessfullyCompile()
+    {
+        var compilation = CompilationHelper.CreateCompilationWithSamePropertyUsedTwice();
+        CompilationHelper.RunSourceGenerator(compilation);
+    }
 }


### PR DESCRIPTION
An update to parse/format so it can handle the same property being used twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for composite primary keys using the same property multiple times, ensuring accurate parsing and formatting.
* **Tests**
  * Introduced comprehensive tests validating serialisation, parsing, formatting, and error handling for composite keys with repeated properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->